### PR TITLE
Add Bold Text Device Setting Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Swash Change Log
 
+## 3.1.0
+- Added bold text setting support
+
 ## 3.0.0
 - Font methods no longer return optionals, for practical reasons
 

--- a/Examples/Shared/Fonts.swift
+++ b/Examples/Shared/Fonts.swift
@@ -21,6 +21,18 @@ enum Avenir: String, Font {
     case oblique = "Avenir-Oblique"
     case roman = "Avenir-Roman"
     case mediumOblique = "Avenir-MediumOblique"
+    
+    static let boldTextMapping: [Avenir : Avenir]? = [
+        light: book,
+        book: roman,
+        roman: medium,
+        medium: heavy,
+        heavy: black,
+        lightOblique: bookOblique,
+        bookOblique: mediumOblique,
+        mediumOblique: heavyOblique,
+        heavyOblique: blackOblique,
+    ]
 }
 
 enum Futura: String, Font {

--- a/Examples/iOS/ViewController.swift
+++ b/Examples/iOS/ViewController.swift
@@ -24,6 +24,20 @@ class ViewController: UIViewController {
 //        label3.adjustsFontForContentSizeCategory = true
 //        label4.adjustsFontForContentSizeCategory = true
         
+        updateFonts()
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(updateFonts), name: UIAccessibility.boldTextStatusDidChangeNotification, object: nil)
+    }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
+            label2.font = Avenir.light.of(style: .title1)
+            label4.font = SystemFont.heavy.of(textStyle: .body)
+        }
+    }
+    
+    @objc private func updateFonts() {
         label1.font = Futura.condensedMedium.of(textStyle: .headline, maxSize: 24)
         label2.font = Avenir.light.of(style: .title1)
         label3.font = SystemFont.preferred.of(textStyle: .caption1)
@@ -35,12 +49,7 @@ class ViewController: UIViewController {
         label4.text = label4.font.fontName
     }
     
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            label2.font = Avenir.light.of(style: .title1)
-            label4.font = SystemFont.heavy.of(textStyle: .body)
-        }
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: UIAccessibility.boldTextStatusDidChangeNotification, object: nil)
     }
-    
 }

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ label3.font = SystemFont.semiboldItalic.of(textStyle: .body, maxSize: 30)
 ```
 **Important note:** [`adjustsFontForContentSizeCategory`](https://developer.apple.com/documentation/uikit/uicontentsizecategoryadjusting/1771731-adjustsfontforcontentsizecategor) only works with `SystemFont` for the `preferred` weight with a nil `maxSize` value. In any other case, you will need to update the font either in [`traitCollectionDidChange(_:)`](https://developer.apple.com/documentation/uikit/uitraitenvironment/1623516-traitcollectiondidchange) or by observing the [`UIContentSizeCategoryDidChange`](https://developer.apple.com/documentation/foundation/nsnotification.name/1622948-uicontentsizecategorydidchange) notification. This is because the `preferred` weight directly returns the result of [`UIFont.preferredFont(forTextStyle:)`](https://developer.apple.com/documentation/uikit/uifont/1619030-preferredfont).
 
+### Bold Text Device Setting
+You can implement the static `boldTextMapping` property on any `Font` in order to support the "Bold Text" device setting on iOS and tvOS.
+```
+static let boldTextMapping: [MyFont: MyFont]? = [
+   .regular: .bold
+]
+```
+
 ### Generate Boilerplate
 Swash can attempt to log your font boilerplate for you!
 ```swift


### PR DESCRIPTION
Added the static `boldTextMapping` property to `Font` in order to support the "Bold Text" device setting on iOS and tvOS.

Example:
```
static let boldTextMapping: [MyFont: MyFont]? = [
   .regular: .bold
]
```