### PR TITLE
Add cascade list functionality

### DIFF
--- a/Examples/Shared/Fonts.swift
+++ b/Examples/Shared/Fonts.swift
@@ -22,17 +22,21 @@ enum Avenir: String, Font {
     case roman = "Avenir-Roman"
     case mediumOblique = "Avenir-MediumOblique"
     
-    static let boldTextMapping: [Avenir : Avenir]? = [
-        light: book,
-        book: roman,
-        roman: medium,
-        medium: heavy,
-        heavy: black,
-        lightOblique: bookOblique,
-        bookOblique: mediumOblique,
-        mediumOblique: heavyOblique,
-        heavyOblique: blackOblique,
-    ]
+    var boldTextMapping: Avenir {
+        switch self {
+        case .light: return .book
+        case .book: return .roman
+        case .roman: return .medium
+        case .medium: return .heavy
+        case .heavy: return .black
+        case .lightOblique: return .bookOblique
+        case .bookOblique: return .mediumOblique
+        case .mediumOblique: return .oblique
+        case .oblique: return .heavyOblique
+        case .heavyOblique: return .blackOblique
+        case .blackOblique, .black: return self
+        }
+    }
 }
 
 enum Futura: String, Font {
@@ -41,6 +45,23 @@ enum Futura: String, Font {
     case condensedExtraBold = "Futura-CondensedExtraBold"
     case condensedMedium = "Futura-CondensedMedium"
     case medium = "Futura-Medium"
+}
+
+enum Papyrus: String, Font {
+    case condensed = "Papyrus-Condensed"
+    case regular = "Papyrus"
+    
+    var cascadeList: [CascadingFontProperties] {
+        [.init(Damascus.regular)]
+    }
+}
+
+enum Damascus: String, Font {
+    case bold = "DamascusBold"
+    case light = "DamascusLight"
+    case regular = "Damascus"
+    case medium = "DamascusMedium"
+    case semiBold = "DamascusSemiBold"
 }
 
 enum InvalidFont: String, Font {

--- a/Examples/iOS/ViewController.swift
+++ b/Examples/iOS/ViewController.swift
@@ -38,12 +38,12 @@ class ViewController: UIViewController {
     }
     
     @objc private func updateFonts() {
-        label1.font = Futura.condensedMedium.of(textStyle: .headline, maxSize: 24)
+        label1.font = Papyrus.regular.of(textStyle: .headline, maxSize: 24)
         label2.font = Avenir.light.of(style: .title1)
         label3.font = SystemFont.preferred.of(textStyle: .caption1)
         label4.font = SystemFont.heavy.of(textStyle: .body)
         
-        label1.text = label1.font.fontName
+        label1.text = "فهو يتحدّث بلغة يونيكود. تسجّل الآن Papyrus -> Damascus"
         label2.text = label2.font.fontName
         label3.text = label3.font.fontName
         label4.text = label4.font.fontName

--- a/Source/CascadingFontProperties.swift
+++ b/Source/CascadingFontProperties.swift
@@ -1,0 +1,10 @@
+
+public struct CascadingFontProperties {
+    public let fontName: String
+    public let boldFontName: String?
+
+    public init<F: Font>(_ font: F) {
+        self.fontName = font.rawValue
+        self.boldFontName = font.boldTextMapping.rawValue
+    }
+}

--- a/Source/Font.swift
+++ b/Source/Font.swift
@@ -87,10 +87,10 @@ public extension Font {
         
         cascadeNames = UIAccessibility.isBoldTextEnabled
             ? cascadeList.map { $0.boldFontName ?? $0.fontName }
-            : cascadeList.map(\.fontName)
+            : cascadeList.map { $0.fontName }
         #else
         fontName = rawValue
-        cascadeNames = cascadeList.map(\.fontName)
+        cascadeNames = cascadeList.map { $0.fontName }
         #endif
         
         guard let font = UIFont(name: fontName, size: size) else {

--- a/Source/Font.swift
+++ b/Source/Font.swift
@@ -37,7 +37,11 @@ public protocol Font: RawRepresentable, Hashable where Self.RawValue == String {
      Example:
      ```
      var cascadeList: [CascadingFontProperties] {
-         [.init(Damascus.regular)]
+         switch self {
+         case .regular:
+             return [.init(Damascus.regular)]
+         case .bold:
+             return [.init(Damascus.bold)]
      }
      ```
      */

--- a/Swash.xcodeproj/project.pbxproj
+++ b/Swash.xcodeproj/project.pbxproj
@@ -36,6 +36,11 @@
 		224BAC74224FF64C00316608 /* DefaultSizes+watchOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224BAC22224F442200316608 /* DefaultSizes+watchOS.swift */; };
 		224BAC75224FF65300316608 /* Swash.h in Headers */ = {isa = PBXBuildFile; fileRef = 224BAC06224F41F100316608 /* Swash.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		224BAC76224FF65400316608 /* Swash.h in Headers */ = {isa = PBXBuildFile; fileRef = 224BAC06224F41F100316608 /* Swash.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		22886BA8242C6E1C009871B7 /* CascadingFontProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22886BA7242C6E1C009871B7 /* CascadingFontProperties.swift */; };
+		22886BA9242C6E1C009871B7 /* CascadingFontProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22886BA7242C6E1C009871B7 /* CascadingFontProperties.swift */; };
+		22886BAA242C6E1C009871B7 /* CascadingFontProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22886BA7242C6E1C009871B7 /* CascadingFontProperties.swift */; };
+		22886BAB242C6E1C009871B7 /* CascadingFontProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22886BA7242C6E1C009871B7 /* CascadingFontProperties.swift */; };
+		22886BAC242C6E1C009871B7 /* CascadingFontProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22886BA7242C6E1C009871B7 /* CascadingFontProperties.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -77,6 +82,7 @@
 		224BAC79224FF85D00316608 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		224BAC98224FFE7400316608 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		224BAC99224FFEB900316608 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
+		22886BA7242C6E1C009871B7 /* CascadingFontProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CascadingFontProperties.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -147,6 +153,7 @@
 			children = (
 				224BAC2C224F443700316608 /* Font.swift */,
 				224BAC2A224F443700316608 /* SystemFont.swift */,
+				22886BA7242C6E1C009871B7 /* CascadingFontProperties.swift */,
 				224BAC2B224F443700316608 /* Utils.swift */,
 				224BAC20224F43F200316608 /* Default Sizes */,
 				224BAC33224F444B00316608 /* Supporting Files */,
@@ -414,6 +421,7 @@
 				224BAC26224F442200316608 /* DefaultSizes+watchOS.swift in Sources */,
 				224BAC24224F442200316608 /* DefaultSizes+tvOS.swift in Sources */,
 				224BAC2D224F443700316608 /* SystemFont.swift in Sources */,
+				22886BA8242C6E1C009871B7 /* CascadingFontProperties.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -422,6 +430,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				224BAC3C224F459500316608 /* TestFonts.swift in Sources */,
+				22886BA9242C6E1C009871B7 /* CascadingFontProperties.swift in Sources */,
 				224BAC39224F44AE00316608 /* CustomFontTests.swift in Sources */,
 				224BAC38224F44AE00316608 /* SystemFontTests.swift in Sources */,
 			);
@@ -437,6 +446,7 @@
 				224BAC5C224FF37C00316608 /* DefaultSizes+iOS.swift in Sources */,
 				224BAC5B224FF37C00316608 /* Utils.swift in Sources */,
 				224BAC5D224FF37C00316608 /* DefaultSizes+tvOS.swift in Sources */,
+				22886BAA242C6E1C009871B7 /* CascadingFontProperties.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -445,6 +455,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				224BAC5F224FF4B500316608 /* TestFonts.swift in Sources */,
+				22886BAB242C6E1C009871B7 /* CascadingFontProperties.swift in Sources */,
 				224BAC61224FF4B500316608 /* CustomFontTests.swift in Sources */,
 				224BAC60224FF4B500316608 /* SystemFontTests.swift in Sources */,
 			);
@@ -460,6 +471,7 @@
 				224BAC72224FF64C00316608 /* DefaultSizes+iOS.swift in Sources */,
 				224BAC71224FF64C00316608 /* Utils.swift in Sources */,
 				224BAC73224FF64C00316608 /* DefaultSizes+tvOS.swift in Sources */,
+				22886BAC242C6E1C009871B7 /* CascadingFontProperties.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Implement the `cascadeList` property (`[]` by default) to apply a cascade list to a font so that it has other options to fall back to if it encounters characters it doesn't support. The feature is covered in [this WWDC talk](https://developer.apple.com/videos/play/wwdc2018/201/).

Also modified the `boldTextMapping` property to be an instance property rather than `static`. It now simply returns a single applicable `Font` instance instead of a dictionary.